### PR TITLE
Fix typo in xor_container.hpp

### DIFF
--- a/src/xor/container/xor_container.hpp
+++ b/src/xor/container/xor_container.hpp
@@ -34,7 +34,7 @@ namespace filters::nxor {
                                                      seeds(other.seeds), base(other.base) {
             other.fingerprints = nullptr;
             for (size_t i = 0; i < offsets.size(); i++) {
-                this->offsets[i] = other.sets[i];
+                this->offsets[i] = other.offsets[i];
                 other.offsets[i] = 0;
             }
         }


### PR DESCRIPTION
Tried to compile the code with GCC 15.2.0 and got an error because the member `set` was missing. Replacing `set` with `offset` fixed it.